### PR TITLE
Bug: Inappropriate Store Config Directive

### DIFF
--- a/app/code/community/Amazon/Login/Block/Script.php
+++ b/app/code/community/Amazon/Login/Block/Script.php
@@ -16,7 +16,7 @@ class Amazon_Login_Block_Script extends Mage_Core_Block_Template
      */
     public function getWidgetsUrl()
     {
-        switch (Mage::getStoreConfig('amazon_login/settings/region')) {
+        switch (Mage::getStoreConfig('payment/amazon_payments/region')) {
           case 'uk':
               $staticRegion = 'eu';
               $widgetRegion = 'uk';


### PR DESCRIPTION
Store config "amazon_login/settings/region" does not exists, and need to be replaced with Payment's "payment/amazon_payments/region".
Or, need to create separate region configuration files (Login / system.xml and Model/System/Config/Source/Region.php).
