### PR TITLE
Fix: Html entity characters issue

### DIFF
--- a/app/code/community/Amazon/Login/Model/Customer.php
+++ b/app/code/community/Amazon/Login/Model/Customer.php
@@ -79,6 +79,7 @@ class Amazon_Login_Model_Customer extends Mage_Customer_Model_Customer
      */
     public function getAmazonName($name)
     {
+        $name = html_entity_decode($name);
         // if the user only has a first name, handle accordingly
         $trimmedName = trim($name);
         if(strpos($trimmedName,' ')===false) {


### PR DESCRIPTION
If name contains space or zen-kaku space, Amazon (Japan) converts name (including Japanese characters) to HTML entities.
